### PR TITLE
Reimplement WriteInt using Utf8Formatter to save a string allocation

### DIFF
--- a/A6k.Nats.Tests/NatsWriterTests.cs
+++ b/A6k.Nats.Tests/NatsWriterTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Buffers;
+using System.Text;
+using A6k.Nats.Operations;
+using A6k.Nats.Protocol;
+using Xunit;
+
+namespace A6k.Nats.Tests
+{
+    public class NatsWriterTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(9999)]
+        [InlineData(-9999)]
+        [InlineData(int.MinValue)]
+        public void WriteInt_must_write_integer_to_buffer_as_a_string(int number)
+        {
+            var buffer = new ArrayBufferWriter<byte>(initialCapacity: 64);
+            var sut = new NatsWriter(buffer);
+            sut.WriteInt(number);
+            sut.Commit();
+
+            var writtenString = Encoding.UTF8.GetString(buffer.WrittenSpan);
+            Assert.Equal(number.ToString(), writtenString);
+        }
+    }
+}

--- a/A6k.Nats/Protocol/NatsWriter.cs
+++ b/A6k.Nats/Protocol/NatsWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
@@ -12,10 +13,18 @@ namespace A6k.Nats.Protocol
 
     public ref partial struct NatsWriter
     {
+        /// <summary>
+        /// Write integer as a string.
+        /// </summary>
+        /// <param name="num"></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteInt(int num)
         {
-            WriteString(num.ToString());
+            const int MaxLength = 11; // The string "-2147483647" (int.MinValue)
+
+            var textSpan = GetSpan(MaxLength);
+            if (Utf8Formatter.TryFormat(num, textSpan, out int bytesWritten))
+                Advance(bytesWritten);
         }
 
         /// <summary>


### PR DESCRIPTION
Uses Utf8Formatter to write int. Adds a test. 