### PR TITLE
Make copy of MSG operation payload more explicit

### DIFF
--- a/A6k.Nats/Operations/MsgOperation.cs
+++ b/A6k.Nats/Operations/MsgOperation.cs
@@ -4,13 +4,13 @@ namespace A6k.Nats.Operations
 {
     public readonly struct MsgOperation
     {
-        public MsgOperation(string subject, string sid, string replyTo, int numBytes, ReadOnlySpan<byte> data)
+        public MsgOperation(string subject, string sid, string replyTo, int numBytes, ReadOnlyMemory<byte> data)
         {
             Subject = subject;
             Sid = sid;
             ReplyTo = replyTo;
             NumBytes = numBytes;
-            Data = data.ToArray();
+            Data = data;
         }
 
         public string Subject { get; }

--- a/A6k.Nats/Protocol/NatsOperationReader.cs
+++ b/A6k.Nats/Protocol/NatsOperationReader.cs
@@ -181,7 +181,9 @@ namespace A6k.Nats.Protocol
             if (!TryReadBytes(ref reader, numBytes, out var data))
                 return false;
 
-            msg = new MsgOperation(subject, sid, replyTo, numBytes, data);
+            // We need to copy the payload data before passing to consumer
+            ReadOnlyMemory<byte> copyOfPayloadData = data.ToArray();
+            msg = new MsgOperation(subject, sid, replyTo, numBytes, copyOfPayloadData);
             return true;
         }
 


### PR DESCRIPTION
The copy of payload for a MSG operation is quite important. It think it should be more explicit.

One could also consider if it's possible to allow users of `NatsClient` provide some `MemoryPool<byte>` to be used when copying the MSG payload. Such MemoryPool would need to be passed from `NatsClient -> NatsClientProtocol -> NatsOperationReader`. 